### PR TITLE
edit fails: Error: no "edit" mailcap rules found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ install-depends:
 		coreutils qemu-system qemu-system-x86 qemu-utils util-linux
 
 config:
-	edit Makevars
+	editor Makevars
 
 .ONESHELL:
 download:


### PR DESCRIPTION
When running this on Ubuntu, I got this error:
```
$ make config 
edit Makevars
Warning: unknown mime-type for "Makevars" -- using "application/octet-stream"
Error: no "edit" mailcap rules found for type "application/octet-stream"
make: *** [Makefile:29: config] Error 3
$ lsb_release -d
Description:    Ubuntu 22.04 LTS
$ dpkg -S $(which edit)
mailcap: /usr/bin/edit
$ readlink -f $(which edit)
/usr/bin/run-mailcap
```

Neither `edit` nor `editor` [seem](https://unix.stackexchange.com/q/316856) to work on all systems, so maybe this PR isn't a lot better than the current state, but at least it now works on my Ubuntu and Debian machines. According to the link, there isn't a perfect simple solution.

N.B. On a Debian system, `edit` ran for Makevars without issues, but it too is a mailcap alias.