### PR TITLE
feat: Docker based builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:bookworm-slim
+
+VOLUME /output
+
+RUN apt-get update \
+	&& apt-get install -y \
+	libarchive-tools syslinux syslinux-utils cpio genisoimage \
+	coreutils qemu-system qemu-system-x86 qemu-utils util-linux \
+	make ca-certificates wget vim nano\
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+COPY ./ /app
+
+WORKDIR /app
+
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ via ssh or serial console.
     # Write image to usb stick
     make usb
 
+## Building with Docker
+
+    make config
+    edit preseed.cfg
+    docker build --tag debian-headless .
+    docker run -it --volume ./output:/output --rm debian-headless
 
 ## Motivation
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+make download
+make image
+mv ./*-hl.iso /output


### PR DESCRIPTION
I tried to use this repo on Arch Linux but some tools were missing or the wrong version was installed. For other users of non-Debian based distros, I've added a Dockerfile and some information in the README on how to build the headless image with it.