### PR TITLE
add hardcoded ssh key and dropbear

### DIFF
--- a/preseed.cfg
+++ b/preseed.cfg
@@ -39,12 +39,45 @@ d-i netcfg/get_domain string local
 d-i hw-detect/load_firmware boolean true
 
 # Setup network console
-d-i preseed/early_command string anna-install network-console
+#
+# It also adds an ssh key so it's possible to ssh using a hardcoded key
+# instead of a hardcoded password
+#
+d-i preseed/early_command string anna-install network-console; \
+mkdir -p /.ssh; \
+/bin/sh -c "echo 'xxxxxxxxxxxxxxxxxxxxx' >> /.ssh/authorized_keys"; \
+chown -R root:root /.ssh/; \
+chmod 600 /.ssh/authorized_keys; \
+chmod 700 /.ssh/
+
 d-i network-console/start select continue
 # Login with password:
-d-i network-console/password password r00tme
-d-i network-console/password-again password r00tme
+#d-i network-console/password password r00tme
+#d-i network-console/password-again password r00tme
+
 # Login with ssh key:
 # d-i network-console/authorized_keys_url string https://my.server/authorized_key
 # disable login with password:
 # d-i network-console/password-disabled boolean true
+
+d-i passwd/root-password-crypted password yyyyyyyyyyyyyyyyyyyyy
+
+# Install dropbear and use it for initramfs. It's only useful for rare cases,
+# like remotely unlocking LUKS.
+# NOTE: it expects dropbear to be in /cdrom/extra/
+# If you have a big installation media, like DLBD, then dropbear is already available
+# and you can replace `cp + dpkg` with `apt-get install`
+
+d-i preseed/late_command string in-target mkdir -p /root/.ssh; \
+in-target /bin/sh -c "echo 'xxxxxxxxxxxxxxxxxxxxx' >> /root/.ssh/authorized_keys"; \
+in-target chown -R root:root /root/.ssh/; \
+in-target chmod 600 /root/.ssh/authorized_keys; \
+in-target chmod 700 /root/.ssh/; \
+in-target apt-get -y install libcrypt1 libtomcrypt1 libtommath1 zlib1g; \
+cp /cdrom/extra/dropbear* /target/tmp; \
+in-target dpkg -i /tmp/dropbear-bin_2022.83-1+deb12u1_amd64.deb; \
+in-target dpkg -i /tmp/dropbear-initramfs_2022.83-1+deb12u1_all.deb; \
+in-target /bin/sh -c "echo 'xxxxxxxxxxxxxxxxxxxxx' >> /etc/dropbear/initramfs/authorized_keys"; \
+in-target /bin/sh -c "echo 'DROPBEAR_OPTIONS=\"-I 300 -j -k -p 6322 -s -c cryptroot-unlock\" ' >> /etc/dropbear/initramfs/dropbear.conf"; \
+in-target update-initramfs -u
+

--- a/preseed.cfg
+++ b/preseed.cfg
@@ -39,45 +39,12 @@ d-i netcfg/get_domain string local
 d-i hw-detect/load_firmware boolean true
 
 # Setup network console
-#
-# It also adds an ssh key so it's possible to ssh using a hardcoded key
-# instead of a hardcoded password
-#
-d-i preseed/early_command string anna-install network-console; \
-mkdir -p /.ssh; \
-/bin/sh -c "echo 'xxxxxxxxxxxxxxxxxxxxx' >> /.ssh/authorized_keys"; \
-chown -R root:root /.ssh/; \
-chmod 600 /.ssh/authorized_keys; \
-chmod 700 /.ssh/
-
+d-i preseed/early_command string anna-install network-console
 d-i network-console/start select continue
 # Login with password:
-#d-i network-console/password password r00tme
-#d-i network-console/password-again password r00tme
-
+d-i network-console/password password r00tme
+d-i network-console/password-again password r00tme
 # Login with ssh key:
 # d-i network-console/authorized_keys_url string https://my.server/authorized_key
 # disable login with password:
 # d-i network-console/password-disabled boolean true
-
-d-i passwd/root-password-crypted password yyyyyyyyyyyyyyyyyyyyy
-
-# Install dropbear and use it for initramfs. It's only useful for rare cases,
-# like remotely unlocking LUKS.
-# NOTE: it expects dropbear to be in /cdrom/extra/
-# If you have a big installation media, like DLBD, then dropbear is already available
-# and you can replace `cp + dpkg` with `apt-get install`
-
-d-i preseed/late_command string in-target mkdir -p /root/.ssh; \
-in-target /bin/sh -c "echo 'xxxxxxxxxxxxxxxxxxxxx' >> /root/.ssh/authorized_keys"; \
-in-target chown -R root:root /root/.ssh/; \
-in-target chmod 600 /root/.ssh/authorized_keys; \
-in-target chmod 700 /root/.ssh/; \
-in-target apt-get -y install libcrypt1 libtomcrypt1 libtommath1 zlib1g; \
-cp /cdrom/extra/dropbear* /target/tmp; \
-in-target dpkg -i /tmp/dropbear-bin_2022.83-1+deb12u1_amd64.deb; \
-in-target dpkg -i /tmp/dropbear-initramfs_2022.83-1+deb12u1_all.deb; \
-in-target /bin/sh -c "echo 'xxxxxxxxxxxxxxxxxxxxx' >> /etc/dropbear/initramfs/authorized_keys"; \
-in-target /bin/sh -c "echo 'DROPBEAR_OPTIONS=\"-I 300 -j -k -p 6322 -s -c cryptroot-unlock\" ' >> /etc/dropbear/initramfs/dropbear.conf"; \
-in-target update-initramfs -u
-

--- a/preseed_with_ssh_keys.cfg
+++ b/preseed_with_ssh_keys.cfg
@@ -43,7 +43,7 @@ d-i hw-detect/load_firmware boolean true
 # It also adds an ssh key so it's possible to ssh using a hardcoded key
 # instead of a hardcoded password
 #
-# The ssh key used is a fake key. Replace it with your key.
+# CONFIG: the ssh key used is a fake key. Replace it with your key.
 
 d-i preseed/early_command string anna-install network-console; \
 mkdir -p /.ssh; \

--- a/preseed_with_ssh_keys.cfg
+++ b/preseed_with_ssh_keys.cfg
@@ -1,0 +1,93 @@
+#### Contents of the preconfiguration file (for stretch)
+### Localization
+# Locale sets language and country.
+d-i debian-installer/locale string en_US.UTF-8
+d-i debian-installer/language string en
+d-i debian-installer/country string DE
+
+# Keyboard selection.
+d-i console-keymaps-at/keymap select us
+d-i keyboard-configuration/xkb-keymap select us
+
+### Network configuration
+#d-i netcfg/choose_interface select eth0
+d-i netcfg/choose_interface select auto
+
+# Any hostname and domain names assigned from dhcp take precedence over
+# values set here. However, setting the values still prevents the questions
+# from being shown, even if values come from dhcp.
+d-i netcfg/get_hostname string tempwatch
+d-i netcfg/get_domain string local
+
+# If you want to force a hostname, regardless of what either the DHCP
+# server returns or what the reverse DNS entry for the IP is, uncomment
+# and adjust the following line.
+#d-i netcfg/hostname string tempwatch
+
+# Static network configuration - uncomment if desired
+#d-i netcfg/disable_autoconfig boolean true
+#d-i netcfg/get_ipaddress string 192.168.0.10
+#d-i netcfg/get_netmask string 255.255.255.0
+#d-i netcfg/get_gateway string 192.168.0.1
+#d-i netcfg/get_nameservers string 192.168.0.1
+#d-i netcfg/confirm_static boolean true
+
+
+# If non-free firmware is needed for the network or other hardware, you can
+# configure the installer to always try to load it, without prompting. Or
+# change to false to disable asking.
+d-i hw-detect/load_firmware boolean true
+
+# Setup network console
+#
+# It also adds an ssh key so it's possible to ssh using a hardcoded key
+# instead of a hardcoded password
+#
+# The ssh key used is a fake key. Replace it with your key.
+
+d-i preseed/early_command string anna-install network-console; \
+mkdir -p /.ssh; \
+/bin/sh -c "echo 'ssh-ed25519 IkxcEAPhTmUlSPMGXtXwGDOyMJoPuPw1vMcoWF1VtyvDX6b1uEG7A68hLEAdaglpEYPs foobar' >> /.ssh/authorized_keys"; \
+chown -R root:root /.ssh/; \
+chmod 600 /.ssh/authorized_keys; \
+chmod 700 /.ssh/
+
+d-i network-console/start select continue
+# Login with password:
+#d-i network-console/password password r00tme
+#d-i network-console/password-again password r00tme
+
+# Login with ssh key:
+# d-i network-console/authorized_keys_url string https://my.server/authorized_key
+# disable login with password:
+# d-i network-console/password-disabled boolean true
+
+# The hashed password. The hash used is 'yescrypt'. The password is r00tme
+d-i passwd/root-password-crypted password $y$j9T$KExqDg1NJD/O8tOKKPFKZ0$0oYiztbbVLLitCPtVd5TKxeB1edk.CusVf3WeIzmvE6
+
+# Install dropbear and use it for initramfs. It's only useful for rare cases,
+# like remotely unlocking LUKS.
+# CONFIG: it expects dropbear to be in /cdrom/extra/
+#   This can be done by putting the following commands into Makefile
+#   at the end of 'unpack' target. Adjust the dropbear files location for your case.
+#     mkdir -p ${TMP}/extra
+#     cp ../distrib/dropbear/* ${TMP}/extra
+#   If you have a big installation media, like DLBD, then dropbear is already available
+#   and you can replace `cp + dpkg` with `apt-get install`
+# CONFIG: the ssh key used is a fake key. Replace it with your key.
+# CONFIG: change the dpkg file names to the ones available in your case.
+# CONFIG: change the dropbear port (6322 in this case) with the one that suits you.
+
+d-i preseed/late_command string in-target mkdir -p /root/.ssh; \
+in-target /bin/sh -c "echo 'ssh-ed25519 IkxcEAPhTmUlSPMGXtXwGDOyMJoPuPw1vMcoWF1VtyvDX6b1uEG7A68hLEAdaglpEYPs foobar' >> /root/.ssh/authorized_keys"; \
+in-target chown -R root:root /root/.ssh/; \
+in-target chmod 600 /root/.ssh/authorized_keys; \
+in-target chmod 700 /root/.ssh/; \
+in-target apt-get -y install libcrypt1 libtomcrypt1 libtommath1 zlib1g; \
+cp /cdrom/extra/dropbear* /target/tmp; \
+in-target dpkg -i /tmp/dropbear-bin_2022.83-1+deb12u1_amd64.deb; \
+in-target dpkg -i /tmp/dropbear-initramfs_2022.83-1+deb12u1_all.deb; \
+in-target /bin/sh -c "echo 'ssh-ed25519 IkxcEAPhTmUlSPMGXtXwGDOyMJoPuPw1vMcoWF1VtyvDX6b1uEG7A68hLEAdaglpEYPs foobar' >> /etc/dropbear/initramfs/authorized_keys"; \
+in-target /bin/sh -c "echo 'DROPBEAR_OPTIONS=\"-I 300 -j -k -p 6322 -s -c cryptroot-unlock\" ' >> /etc/dropbear/initramfs/dropbear.conf"; \
+in-target update-initramfs -u
+


### PR DESCRIPTION
This is an unpolished example of:
- using an ssh key, which can save a few keystrokes on connect
- using encrypted passwords
- using dropbear in initramfs, which can be useful for remote LUKS unlocking
