### PR TITLE
Fix: Replace ${tmp} with ${TMP} in Makefile line 83

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ iso: ${TMP}
 		-r -J -b isolinux/isolinux.bin -c isolinux/boot.cat \
 		-no-emul-boot -boot-load-size 4 -boot-info-table \
 		-eltorito-alt-boot \
-		-e ${tmp} boot/grub/efi.img \
+		-e ${TMP} boot/grub/efi.img \
 		-no-emul-boot \
 		-o ${TARGET} ${TMP}
 	isohybrid --uefi ${TARGET}


### PR DESCRIPTION
Fixed typo in variable name: replaced ${tmp} with ${TMP} to match the rest of the code in Makefile.